### PR TITLE
chore: use inputPath

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -7,14 +7,14 @@ const rule = require('../src');
 tester.run('eol-last', rule, {
   valid: [
     {
-      text: ''
+      inputPath: 'test/fixtures/empty-string.txt'
     },
     {
       text: `foo
 `
     },
     {
-      text: '',
+      inputPath: 'test/fixtures/empty-string.txt',
       options: {
         newline: 'never'
       }


### PR DESCRIPTION
Fixes the error:

```
Error: valid should have text or inputPath property.

valid: [ "text", { text: "text" }, { inputPath: "path/to/file" } ]
```